### PR TITLE
fixed typescript errors in sanity files

### DIFF
--- a/sanity/plugins/settings.tsx
+++ b/sanity/plugins/settings.tsx
@@ -2,7 +2,7 @@
  * This plugin contains all the logic for setting up the singletons
  */
 
-import { type DocumentDefinition } from 'sanity';
+import { TemplateItem, type DocumentDefinition } from 'sanity';
 import { type StructureResolver } from 'sanity/structure';
 
 export const singletonPlugin = (types: string[]) => {
@@ -11,17 +11,22 @@ export const singletonPlugin = (types: string[]) => {
     document: {
       // Hide 'Singletons (such as Home)' from new document options
       // https://user-images.githubusercontent.com/81981/195728798-e0c6cf7e-d442-4e58-af3a-8cd99d7fcc28.png
-      newDocumentOptions: (prev, { creationContext }) => {
+      newDocumentOptions: (
+        prev: any[],
+        { creationContext }: { creationContext: { type: string } },
+      ) => {
         if (creationContext.type === 'global') {
-          return prev.filter(templateItem => !types.includes(templateItem.templateId));
+          return prev.filter(
+            (templateItem: TemplateItem) => !types.includes(templateItem.templateId),
+          );
         }
 
         return prev;
       },
       // Removes the "duplicate" action on the Singletons (such as Home)
-      actions: (prev, { schemaType }) => {
+      actions: (prev: any[], { schemaType }: { schemaType: string }) => {
         if (types.includes(schemaType)) {
-          return prev.filter(({ action }) => action !== 'duplicate');
+          return prev.filter(({ action }: { action: string }) => action !== 'duplicate');
         }
 
         return prev;

--- a/sanity/schemas/objects/timeline.ts
+++ b/sanity/schemas/objects/timeline.ts
@@ -44,7 +44,8 @@ export const timeline = defineType({
             prepare({ items, title }) {
               const hasItems = items && items.length > 0;
               const milestoneNames =
-                hasItems && items.map((timeline: { title: any }) => timeline.title).join(', ');
+                hasItems &&
+                (items ?? []).map((timeline: { title: string }) => timeline.title).join(', ');
 
               return {
                 subtitle: hasItems
@@ -62,9 +63,10 @@ export const timeline = defineType({
     select: {
       items: 'items',
     },
-    prepare({ items }: { items: { title: string }[] }) {
+    prepare({ items }: Record<string, any>) {
       const hasItems = items && items.length > 0;
-      const timelineNames = hasItems && items.map(timeline => timeline.title).join(', ');
+      const timelineNames =
+        hasItems && (items ?? []).map((timeline: { title: any }) => timeline.title).join(', ');
 
       return {
         title: 'Timelines',


### PR DESCRIPTION
@kaleemullahdev, we are having typescript errors on `dev` while generating a build using `pnpm run build`. This PR addresses those errors by adding a temporary fix. We used `any` in some cases in the sanity schema files because these files are just for the testing purpose for now and will be removed later on.